### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,35 +1,85 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: .NET
+name: Build & Publish NuGet to GitHub Registry
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
+    branches: [main]
+      
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest    
+    outputs: 
+      Version: ${{ steps.gitversion.outputs.SemVer }}
+      CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }} 
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 #fetch-depth is needed for GitVersion
+        
+    #Install and calculate the new version with GitVersion  
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.10.2
+      with:
+        versionSpec: 5.x
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v0.10.2
+      id: gitversion # step id used as reference for output values
+    - name: Display GitVersion outputs
+      run: |
+        echo "Version: ${{ steps.gitversion.outputs.SemVer }}"
+        echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}"
+    
+# Build/pack the project
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
+
     - name: Restore dependencies
-      run: dotnet restore src/Aspire.Hosting.Waha/Aspire.Hosting.Waha.csproj
+      run: dotnet restore ${{ vars.CS_PROJ_PATH }}
+      
     - name: Build
-      run: dotnet build src/Aspire.Hosting.Waha/Aspire.Hosting.Waha.csproj --configuration Release
-    - name: Test
-      run: dotnet test src/Aspire.Hosting.Waha.Test/Aspire.Hosting.Waha.Test.csproj --no-build --verbosity normal
-    - name: Pack
-      run: dotnet pack src/Aspire.Hosting.Waha/Aspire.Hosting.Waha.csproj --no-build --configuration Release --output ./nupkg
-    - name: Publish Nuget
-      env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push ./nupkg/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
-          
+      run: dotnet build ${{ vars.CS_PROJ_PATH }} --configuration Release
+ 
+    - name: Pack NuGet package with versioning
+      run: dotnet pack ${{ vars.CS_PROJ_PATH }} -p:Version='${{ steps.gitversion.outputs.SemVer }}' -c Release -o bin/Release
+
+    - name: Upload NuGet package to GitHub
+      uses: actions/upload-artifact@v4
+      with:
+        name: nugetPackage
+        path: src/bin/Release/*.nupkg
+
+  release:
+    runs-on: ubuntu-latest    
+    needs: build
+    if: github.ref == 'refs/heads/main' # only run job if on the main branch   
+    
+    steps: 
+    #Push NuGet package to GitHub packages and Nuget.org
+    - name: Download nuget package artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: nugetPackage
+        path: nugetPackage
+        
+    - name: Prep packages
+      run: dotnet nuget add source --username ${{ vars.USERNAME }} --password ${{ secrets.NUGET_PACKAGE_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ vars.USERNAME }}/index.json"
+    
+    - name: Push package to GitHub packages 
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 #Only release if there has been a commit/version change  
+      run: dotnet nuget push nugetPackage/*.nupkg --api-key ${{ secrets.NUGET_PACKAGE_TOKEN }} --source "github" --skip-duplicate
+    
+    - name: Push package to nuget.org
+      if: needs.build.outputs.CommitsSinceVersionSource > 0
+      run: dotnet nuget push nugetPackage/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+    
+    #Create release
+    - name: Create Release
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 #Only release if there has been a commit/version change
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ needs.build.outputs.Version }}
+        name: Release ${{ needs.build.outputs.Version }}
+        artifacts: "nugetPackage/*"
+        token: ${{ secrets.NUGET_PACKAGE_TOKEN }}


### PR DESCRIPTION
- [x] close #3 

This pull request updates the `.github/workflows/dotnet.yml` file to enhance the build and publish process for a .NET project. The most significant changes include renaming the workflow, adding steps for versioning with GitVersion, and modifying the build, pack, and publish steps to integrate with GitHub and NuGet.

Enhancements to the build and publish process:

* Renamed the workflow to "Build & Publish NuGet to GitHub Registry" for clarity.
* Added steps to install and determine the version using GitVersion, which includes displaying the version outputs.
* Modified the `dotnet restore` and `dotnet build` steps to use a variable for the project path (`${{ vars.CS_PROJ_PATH }}`).
* Added steps to pack the NuGet package with versioning and upload it as an artifact.
* Introduced a new `release` job to push the NuGet package to GitHub packages and NuGet.org, and create a release if there has been a commit/version change.